### PR TITLE
Add bundler 1.1 support

### DIFF
--- a/src/broom.sh
+++ b/src/broom.sh
@@ -27,7 +27,7 @@ VERSION=dev
 # Tools definitions
 # ----------------------------------------------------------------------
 
-AVAILABLE_TOOLS=(make rake python ant mvn gradle buildr sbt ninja git)
+AVAILABLE_TOOLS=(make rake python ant mvn gradle buildr sbt ninja git bundle)
 
 # Make
 make_project_marker() { echo "Makefile"; }
@@ -63,6 +63,9 @@ ninja_clean_args()  { echo "-t clean"; }
 # Git gc
 git_project_marker() { echo ".git/"; }
 git_clean_args()  { echo "gc"; }
+
+# Bundler
+bundle_project_marker() { echo "Gemfile"; }
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Bundler 1.1 has a `bundle clean` command that removes unused gems from the project's local gem repository. The clean command will only affect Bundler projects where the `path` setting is specified (i.e. a local gem repository is specified). Bundler projects can be identified by the presence of a `Gemfile`.
