### PR TITLE
Execute clean commands in a subshell

### DIFF
--- a/src/broom.sh
+++ b/src/broom.sh
@@ -195,7 +195,7 @@ for tool in ${TOOLS[@]}; do
             info $clean_command
           else
             info "Cleaning $tool project `dirname $marker`... "
-            is_log_level 2 && eval $clean_command || eval $clean_command &> /dev/null
+            is_log_level 2 && (eval $clean_command) || (eval $clean_command &> /dev/null)
           fi
         fi
       fi


### PR DESCRIPTION
Each clean command alters the working directory with `cd` and does not reset it. This means that if several project directories are found (identified by relative paths), the first directory will be cleaned, but all subsequent directories will fail now that the project paths are no longer valid relative to the altered working directory.

Solve this by wrapping the `eval` clean command statements in parentheses, [which will cause them to be executed in a subshell](http://superuser.com/a/231884). This means the working directory will not be altered in the master loop.

My shell scripting knowledge is limited, so this may not be the best solution. I'd appreciate feedback.
